### PR TITLE
beta: Automate beta releases of notehub js SDK to npm 

### DIFF
--- a/.github/workflows/create-beta-pr.yml
+++ b/.github/workflows/create-beta-pr.yml
@@ -1,0 +1,21 @@
+name: Automatically create / update beta pull request
+
+# run this workflow only on new beta testing feature branches
+on:
+  push:
+    branches:
+      - "test-release-*"
+
+jobs:
+  create_pr_repo_sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create pull request
+        id: open-pr
+        uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: "main"
+          pr_title: "beta: PLACEHOLDER TITLE"
+          pr_template: ".github/PULL_REQUEST_TEMPLATE.md"
+          pr_draft: true

--- a/.github/workflows/create-beta-pr.yml
+++ b/.github/workflows/create-beta-pr.yml
@@ -16,6 +16,4 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"
-          pr_title: "beta: PLACEHOLDER TITLE"
-          pr_template: ".github/PULL_REQUEST_TEMPLATE.md"
           pr_draft: true

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -10,7 +10,7 @@ on:
       dry_run:
         description: "If true, run without actually publishing the package"
         required: false
-        default: "true"
+        default: "false"
 
 jobs:
   publish-beta:
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current version from config.json
         id: get_version
@@ -30,14 +30,11 @@ jobs:
       - name: Update Version to Beta
         id: update_version
         run: |
-          # Extract major, minor, and patch parts of the version
-          IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
-
           # Get the beta suffix from the input
           BETA_SUFFIX=${{ github.event.inputs.beta_version_suffix }}
 
           # Update the version to include the beta identifier
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
+          NEW_VERSION="$CURRENT_VERSION-beta.$BETA_SUFFIX"
 
           # Update config.json with the new version
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
@@ -57,7 +54,7 @@ jobs:
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish Beta Version to npm
@@ -68,7 +65,6 @@ jobs:
           else
             npm publish --tag next --access public
           fi
-
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -64,6 +64,11 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install dependencies
+        run: |
+          cd src
+          npm install
+
       - name: Publish Beta Version to npm
         run: |
           echo "Publishing beta version to npm... $NEW_VERSION"

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -31,11 +31,14 @@ jobs:
       - name: Update Version to Beta
         id: update_version
         run: |
+          # Extract major, minor, and patch parts of the version
+          IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
+
           # Get the beta suffix from the input
           BETA_SUFFIX=${{ github.event.inputs.beta_version_suffix }}
 
           # Update the version to include the beta identifier
-          NEW_VERSION="$CURRENT_VERSION-beta.$BETA_SUFFIX"
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
 
           # Update config.json with the new version
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -1,6 +1,7 @@
 name: Publish beta version of notehub-js to npm
 
 on:
+  # todo refactor to be automated version bump upon update to PR with branch name of `text-release-*`
   workflow_dispatch:
     inputs:
       beta_version_suffix:
@@ -63,7 +64,7 @@ jobs:
           if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
             echo "Dry run mode enabled: Skipping actual npm publish"
           else
-            npm publish --tag next --access public
+            npm publish --tag beta --access public
           fi
 
         env:

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -10,7 +10,7 @@ on:
       dry_run:
         description: "If true, run without actually publishing the package"
         required: false
-        default: "false"
+        default: "true"
 
 jobs:
   publish-beta:
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Get current version from config.json
         id: get_version
@@ -30,11 +30,14 @@ jobs:
       - name: Update Version to Beta
         id: update_version
         run: |
+          # Extract major, minor, and patch parts of the version
+          IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
+
           # Get the beta suffix from the input
           BETA_SUFFIX=${{ github.event.inputs.beta_version_suffix }}
 
           # Update the version to include the beta identifier
-          NEW_VERSION="$CURRENT_VERSION-beta.$BETA_SUFFIX"
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
 
           # Update config.json with the new version
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
@@ -54,7 +57,7 @@ jobs:
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish Beta Version to npm
@@ -65,6 +68,7 @@ jobs:
           else
             npm publish --tag next --access public
           fi
+
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -22,32 +22,35 @@ jobs:
           echo "Current project version: $CURRENT_VERSION"
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
-      - name: Increment Beta Version
-        id: update_version
+      - name: Get existing beta versions from npm
+        id: get_existing_versions
         run: |
-          # Check if the current version already has a beta suffix
-          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-beta\.([0-9]+))?$ ]]; then
-            # Extract major, minor, patch, and the current beta version number
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            PATCH="${BASH_REMATCH[3]}"
-            CURRENT_BETA="${BASH_REMATCH[5]:-0}"  # Use 0 if no beta suffix is present
+          # Query npm for existing versions of the package
+          EXISTING_VERSIONS=$(npm show @blues-inc/notehub-js versions --json)
+          echo "Existing versions on npm: $EXISTING_VERSIONS"
 
-            # Increment the beta version by 1
-            NEW_BETA=$((CURRENT_BETA + 1))
-            
-            # Construct the new version with the incremented beta suffix
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$NEW_BETA"
-          else
-            echo "Error: Current version format is not compatible. Please ensure it follows the semantic versioning format."
-            exit 1
-          fi
+          # Extract only beta versions for the current major.minor.patch version
+          CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${CURRENT_VERSION}-beta\.[0-9]+$")
+          echo "Current beta versions: $CURRENT_BETA_VERSIONS"
 
-          # Update config.json with the new version
-          jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
+          # Get the highest beta version number and increment it
+          HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | grep -oE 'beta\.[0-9]+' | sort -V | tail -n 1 | grep -oE '[0-9]+')
+          NEXT_BETA_VERSION=$((HIGHEST_BETA_VERSION + 1))
+          echo "Next beta version: $NEXT_BETA_VERSION"
+
+          # Use the branch name to create a unique version suffix
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          UNIQUE_VERSION="${CURRENT_VERSION}-beta.${NEXT_BETA_VERSION}-${BRANCH_NAME}"
+
+          echo "Updated version will be: $UNIQUE_VERSION"
+          echo "NEW_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
+
+      - name: Update version to beta
+        run: |
+          # Update config.json with the new beta version
+          jq --arg new_version "$NEW_VERSION" '.projectVersion = $NEW_VERSION' config.json > config.tmp.json && mv config.tmp.json config.json
 
           echo "Updated project version to: $NEW_VERSION"
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: npm install
@@ -72,8 +75,8 @@ jobs:
       - name: Publish Beta Version to npm
         run: |
           echo "Publishing beta version to npm... $NEW_VERSION"
-          cd src
-          npm publish --tag beta --access public
+          # cd src
+          # npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -29,32 +29,32 @@ jobs:
           EXISTING_VERSIONS=$(npm show @blues-inc/notehub-js versions --json)
           echo "Existing versions on npm: $EXISTING_VERSIONS"
 
-          # Extract only beta versions for the current major.minor.patch version
+          # Extract beta versions for the current major.minor.patch version using regex
           CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${CURRENT_VERSION}-beta\.[0-9]+$" || true)
           echo "Current beta versions: $CURRENT_BETA_VERSIONS"
 
+          # If no beta versions exist, set the initial beta version number
           if [ -z "$CURRENT_BETA_VERSIONS" ]; then
-            # If no beta versions exist, set the initial beta version number
             NEXT_BETA_VERSION=1
           else
             # Get the highest beta version number and increment it
-            HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | grep -oE 'beta\.[0-9]+' | sort -V | tail -n 1 | grep -oE '[0-9]+')
+            HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | sed -E 's/.*-beta\.([0-9]+)$/\1/' | sort -n | tail -n 1)
             NEXT_BETA_VERSION=$((HIGHEST_BETA_VERSION + 1))
           fi
-          echo "Next beta version: $NEXT_BETA_VERSION"
 
-          # Use the branch name to create a unique version suffix
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          UNIQUE_VERSION="${CURRENT_VERSION}-beta.${NEXT_BETA_VERSION}-${BRANCH_NAME}"
+          # Set the new version as `MAJOR.MINOR.PATCH-beta.N`
+          NEW_VERSION="${CURRENT_VERSION%-beta.*}-beta.$NEXT_BETA_VERSION"
 
-          echo "Updated version will be: $UNIQUE_VERSION"
-          echo "NEW_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
-      - name: Update version to beta
-        run: |
-          # Update config.json with the new beta version
-          jq --arg new_version "$NEW_VERSION" '.projectVersion = $NEW_VERSION' config.json > config.tmp.json && mv config.tmp.json config.json
+          echo "Next beta version: $NEW_VERSION"
 
-          echo "Updated project version to: $NEW_VERSION"
+          # Save to GitHub environment variables
+          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
+            - name: Update version to beta
+              run: |
+                # Update config.json with the new beta version
+                jq --arg new_version "$new_version" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
+
+                echo "Updated project version to: $new_version"
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(jq -r .projectVersion config.json)
           echo "Current project version: $CURRENT_VERSION"
-          echo "current_version=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
       - name: Update Version to Beta
         id: update_version
@@ -53,7 +53,7 @@ jobs:
         run: npm run generateDocs
 
       - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -1,17 +1,11 @@
 name: Publish beta version of notehub-js to npm
 
 on:
-  # todo refactor to be automated version bump upon update to PR with branch name of `text-release-*`
-  workflow_dispatch:
-    inputs:
-      beta_version_suffix:
-        description: 'Beta version suffix, e.g., "1", "2" for 1.0.21-beta.1, 1.0.21-beta.2'
-        required: true
-        default: "1"
-      dry_run:
-        description: "If true, run without actually publishing the package"
-        required: false
-        default: "false"
+  push:
+    branches:
+      - "test-release-*"
+    paths:
+      - "openapi.yaml"
 
 jobs:
   publish-beta:
@@ -28,20 +22,22 @@ jobs:
           echo "Current project version: $CURRENT_VERSION"
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
-      - name: Update Version to Beta
+      - name: Increment Beta Version
         id: update_version
         run: |
-          # Get the beta suffix from the input
-          BETA_SUFFIX="${{ github.event.inputs.beta_version_suffix }}"
-
-          # If the current version already has a beta suffix, replace it with the new one
-          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-beta\.[0-9]+)?$ ]]; then
-            # Extract major, minor, and patch parts of the version
+          # Check if the current version already has a beta suffix
+          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-beta\.([0-9]+))?$ ]]; then
+            # Extract major, minor, patch, and the current beta version number
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
-            # Replace or add the new beta suffix
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
+            CURRENT_BETA="${BASH_REMATCH[5]:-0}"  # Use 0 if no beta suffix is present
+
+            # Increment the beta version by 1
+            NEW_BETA=$((CURRENT_BETA + 1))
+            
+            # Construct the new version with the incremented beta suffix
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$NEW_BETA"
           else
             echo "Error: Current version format is not compatible. Please ensure it follows the semantic versioning format."
             exit 1
@@ -70,13 +66,9 @@ jobs:
 
       - name: Publish Beta Version to npm
         run: |
-          cd src
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
-            echo "Dry run mode enabled: Skipping actual npm publish"
-          else
-            npm publish --tag beta --access public
-          fi
-
+          echo "Publishing beta version to npm... $NEW_VERSION"
+          # cd src
+          # npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -10,7 +10,7 @@ on:
       dry_run:
         description: "If true, run without actually publishing the package"
         required: false
-        default: "true"
+        default: "false"
 
 jobs:
   publish-beta:
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current version from config.json
         id: get_version
@@ -30,14 +30,11 @@ jobs:
       - name: Update Version to Beta
         id: update_version
         run: |
-          # Extract major, minor, and patch parts of the version
-          IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
-
           # Get the beta suffix from the input
           BETA_SUFFIX=${{ github.event.inputs.beta_version_suffix }}
 
           # Update the version to include the beta identifier
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
+          NEW_VERSION="$CURRENT_VERSION-beta.$BETA_SUFFIX"
 
           # Update config.json with the new version
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
@@ -57,7 +54,7 @@ jobs:
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish Beta Version to npm

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -82,9 +82,9 @@ jobs:
 
       - name: Publish Beta Version to npm
         run: |
-          echo "Publishing beta version to npm... $NEW_VERSION"
-          # cd src
-          # npm publish --tag beta --access public
+          echo "Publishing beta version to npm... $new_version"
+          cd src
+          npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -47,7 +47,7 @@ jobs:
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
 
           echo "Updated project version to: $NEW_VERSION"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -31,14 +31,21 @@ jobs:
       - name: Update Version to Beta
         id: update_version
         run: |
-          # Extract major, minor, and patch parts of the version
-          IFS='.' read -r MAJOR MINOR PATCH <<<"$CURRENT_VERSION"
-
           # Get the beta suffix from the input
-          BETA_SUFFIX=${{ github.event.inputs.beta_version_suffix }}
+          BETA_SUFFIX="${{ github.event.inputs.beta_version_suffix }}"
 
-          # Update the version to include the beta identifier
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
+          # If the current version already has a beta suffix, replace it with the new one
+          if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-beta\.[0-9]+)?$ ]]; then
+            # Extract major, minor, and patch parts of the version
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            # Replace or add the new beta suffix
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH-beta.$BETA_SUFFIX"
+          else
+            echo "Error: Current version format is not compatible. Please ensure it follows the semantic versioning format."
+            exit 1
+          fi
 
           # Update config.json with the new version
           jq --arg new_version "$NEW_VERSION" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -29,32 +29,36 @@ jobs:
           EXISTING_VERSIONS=$(npm show @blues-inc/notehub-js versions --json)
           echo "Existing versions on npm: $EXISTING_VERSIONS"
 
-          # Extract beta versions for the current major.minor.patch version using regex
-          CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${CURRENT_VERSION}-beta\.[0-9]+$" || true)
+          # Extract current version without any existing beta suffix
+          BASE_VERSION=$(echo "$CURRENT_VERSION" | sed -E 's/-beta\.[0-9]+$//')
+
+          # Extract only the beta versions for the current base version (e.g., 1.0.23-beta.X)
+          CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${BASE_VERSION}-beta\.[0-9]+$" || true)
           echo "Current beta versions: $CURRENT_BETA_VERSIONS"
 
-          # If no beta versions exist, set the initial beta version number
+          # Determine the next beta version number
           if [ -z "$CURRENT_BETA_VERSIONS" ]; then
             NEXT_BETA_VERSION=1
           else
-            # Get the highest beta version number and increment it
+            # Extract numeric suffixes of all beta versions, sort, and get the highest
             HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | sed -E 's/.*-beta\.([0-9]+)$/\1/' | sort -n | tail -n 1)
             NEXT_BETA_VERSION=$((HIGHEST_BETA_VERSION + 1))
           fi
 
           # Set the new version as `MAJOR.MINOR.PATCH-beta.N`
-          NEW_VERSION="${CURRENT_VERSION%-beta.*}-beta.$NEXT_BETA_VERSION"
+          NEW_VERSION="${BASE_VERSION}-beta.$NEXT_BETA_VERSION"
 
           echo "Next beta version: $NEW_VERSION"
 
           # Save to GitHub environment variables
           echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
-            - name: Update version to beta
-              run: |
-                # Update config.json with the new beta version
-                jq --arg new_version "$new_version" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
 
-                echo "Updated project version to: $new_version"
+      - name: Update version to beta
+        run: |
+          # Update config.json with the new beta version
+          jq --arg new_version "$new_version" '.projectVersion = $new_version' config.json > config.tmp.json && mv config.tmp.json config.json
+
+          echo "Updated project version to: $new_version"
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -30,12 +30,17 @@ jobs:
           echo "Existing versions on npm: $EXISTING_VERSIONS"
 
           # Extract only beta versions for the current major.minor.patch version
-          CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${CURRENT_VERSION}-beta\.[0-9]+$")
+          CURRENT_BETA_VERSIONS=$(echo "$EXISTING_VERSIONS" | jq -r '.[]' | grep -E "^${CURRENT_VERSION}-beta\.[0-9]+$" || true)
           echo "Current beta versions: $CURRENT_BETA_VERSIONS"
 
-          # Get the highest beta version number and increment it
-          HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | grep -oE 'beta\.[0-9]+' | sort -V | tail -n 1 | grep -oE '[0-9]+')
-          NEXT_BETA_VERSION=$((HIGHEST_BETA_VERSION + 1))
+          if [ -z "$CURRENT_BETA_VERSIONS" ]; then
+            # If no beta versions exist, set the initial beta version number
+            NEXT_BETA_VERSION=1
+          else
+            # Get the highest beta version number and increment it
+            HIGHEST_BETA_VERSION=$(echo "$CURRENT_BETA_VERSIONS" | grep -oE 'beta\.[0-9]+' | sort -V | tail -n 1 | grep -oE '[0-9]+')
+            NEXT_BETA_VERSION=$((HIGHEST_BETA_VERSION + 1))
+          fi
           echo "Next beta version: $NEXT_BETA_VERSION"
 
           # Use the branch name to create a unique version suffix
@@ -44,7 +49,6 @@ jobs:
 
           echo "Updated version will be: $UNIQUE_VERSION"
           echo "NEW_VERSION=$UNIQUE_VERSION" >> $GITHUB_ENV
-
       - name: Update version to beta
         run: |
           # Update config.json with the new beta version

--- a/.github/workflows/publish-beta-npm.yml
+++ b/.github/workflows/publish-beta-npm.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Publish Beta Version to npm
         run: |
           echo "Publishing beta version to npm... $NEW_VERSION"
-          # cd src
-          # npm publish --tag beta --access public
+          cd src
+          npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ to [npm](https://www.npmjs.com/package/@blues-inc/notehub-js) for ease of use in
     - [Testing the Library Locally](#testing-the-library-locally)
   - [Deploying notehub-js to npm](#deploying-notehub-js-to-npm)
     - [Steps to Publish an Updated npm Version of Repo](#steps-to-publish-an-updated-npm-version-of-repo)
+    - [Steps to Publish a Beta Version of Repo to npm](#steps-to-publish-a-beta-version-of-repo-to-npm)
   - [Contributing](#contributing)
     - [Resources](#resources)
   - [To learn more about Blues Wireless, the Notecard and Notehub, see:](#to-learn-more-about-blues-wireless-the-notecard-and-notehub-see)
@@ -339,6 +340,21 @@ _Copy the formatted changelog notes from the GH Action workflow run._
 
 ![Paste changelog notes into release tag in GH](images/update-changelog-github.png)
 _Paste the notes into the newest release tag._
+
+### Steps to Publish a Beta Version of Repo to npm
+
+During the course of the development cycle, it may make sense to have beta versions of a repo available on npm for testing purposes. These versions of the notehub-js repo are considered unstable and should not be used long term in production apps, they are meant for internal testing of new features before they're ready for public consumption. Here are the steps to deploy a beta version of the SDK to npm:
+
+1. Create a new feature branch with the name `test-release-BRANCH-NAME-OF-CHOICE`, and modify the `openapi.yaml` file. Commit that new branch back to the Notehub JS repo.
+2. Once committed, two GitHub Action workflows will detect the branch name contains `test-release-*` and one will create a new PR to document that a new beta release of the Notehub JS SDK is happening, and the other will actually perform the release automatically (update the project version with a `beta.XX` tag, regenerate the SDK with the new `openapi.yaml` file, publish it as a beta version to npm, commit the newly update project version back to the PR, etc.)
+
+Now, anyone can download the beta version of the Notehub JS with the following command:
+
+```shell
+npm install @blues-inc/notehub-js@1.0.23-beta.XX
+```
+
+You can see all available project versions by visiting the [Notehub JS npm page and clicking the "Versions" tab](https://www.npmjs.com/package/@blues-inc/notehub-js?activeTab=versions).
 
 ## Contributing
 

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.2-beta.3",
+  "projectVersion": "1.0.23-beta.3",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "-beta.1-beta.2",
+  "projectVersion": "1.0.23-beta.2",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.4",
+  "projectVersion": "1.0.23-beta.5",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.2",
+  "projectVersion": "1.0.23",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23",
+  "projectVersion": "-beta.1",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.3",
+  "projectVersion": "1.0.23-beta.3-beta.4",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.1",
+  "projectVersion": "1.0.23",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.1",
+  "projectVersion": "1.0.23-beta.2",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "-beta.1",
+  "projectVersion": "-beta.1-beta.2",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.5",
+  "projectVersion": "1.0.23",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.3-beta.4",
+  "projectVersion": "1.0.23-beta.4",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23",
+  "projectVersion": "1.0.23-beta.3",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23",
+  "projectVersion": "1.0.23-beta.1",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "licenseName": "MIT",
   "moduleName": "NotehubJs",
   "npmRepository": "https://registry.npmjs.org",
-  "projectVersion": "1.0.23-beta.2",
+  "projectVersion": "1.0.23-beta.2-beta.3",
   "sourceFolder": "src",
   "usePromises": true
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,9 +3,9 @@ openapi: "3.0.3"
 
 info:
   title: Notehub API
-  version: 1.1.1
+  version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Beta test change
+    The OpenAPI definition for the Notehub.io API. Beta test change.
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Beta test change 3.
+    The OpenAPI definition for the Notehub.io API. Beta test change 4.
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Change 2
+    The OpenAPI definition for the Notehub.io API. Change 3
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: "3.0.3"
 
 info:
   title: Notehub API
-  version: 1.1.0
+  version: 1.1.1
   description: |
     The OpenAPI definition for the Notehub.io API. Beta test change
   contact:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Change 3
+    The OpenAPI definition for the Notehub.io API. Change 5
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Change 1
+    The OpenAPI definition for the Notehub.io API. Change 2
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API.
+    The OpenAPI definition for the Notehub.io API
   contact:
     name: Blues Engineering
     email: engineering@blues.io
@@ -2514,9 +2514,7 @@ components:
       style: form
       explode: true
       schema:
-        type: array
-        items:
-          type: string
+        type: string
 
     tagParam:
       name: tag

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Beta test change 4.
+    The OpenAPI definition for the Notehub.io API.
   contact:
     name: Blues Engineering
     email: engineering@blues.io
@@ -2514,7 +2514,9 @@ components:
       style: form
       explode: true
       schema:
-        type: string
+        type: array
+        items:
+          type: string
 
     tagParam:
       name: tag

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: "3.0.3"
 
 info:
   title: Notehub API
-  version: 1.1.2
+  version: 1.1.1
   description: |
     The OpenAPI definition for the Notehub.io API. Beta test change
   contact:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API
+    The OpenAPI definition for the Notehub.io API. Change 1
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Change 5
+    The OpenAPI definition for the Notehub.io API. Change
   contact:
     name: Blues Engineering
     email: engineering@blues.io
@@ -1201,7 +1201,7 @@ paths:
             items:
               type: string
         - name: since
-          description: Deprecated. 
+          description: Deprecated.
           in: query
           required: false
           deprecated: true
@@ -1293,7 +1293,7 @@ paths:
             items:
               type: string
         - name: since
-          description: Deprecated. 
+          description: Deprecated.
           in: query
           required: false
           deprecated: true
@@ -2587,8 +2587,6 @@ components:
         type: array
         items:
           type: string
-
-
 
   responses:
     ErrorResponse:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Beta test change 2.
+    The OpenAPI definition for the Notehub.io API. Beta test change 3.
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Change
+    The OpenAPI definition for the Notehub.io API. Beta test change
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Notehub API
   version: 1.1.0
   description: |
-    The OpenAPI definition for the Notehub.io API. Beta test change.
+    The OpenAPI definition for the Notehub.io API. Beta test change 2.
   contact:
     name: Blues Engineering
     email: engineering@blues.io

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: "3.0.3"
 
 info:
   title: Notehub API
-  version: 1.1.1
+  version: 1.1.2
   description: |
     The OpenAPI definition for the Notehub.io API. Beta test change
   contact:


### PR DESCRIPTION
# Problem Context

During the course of the development cycle, it may make sense to have beta versions of a repo available on npm for testing purposes. These versions of the notehub-js repo are considered unstable and should not be used long term in production apps, they are meant for internal testing of new features before they're ready for public consumption.

## Changes

* Create new GH Action workflow PR so we can have a new PR for every beta version of the Notehub JS SDK released. Even if the PRs are never merged in, we have a record of them being created and then closed.
* Create another new GH Action that performs the beta release to npm automatically (update the project version with a `beta.XX` tag, regenerate the SDK with the new `openapi.yaml` file, publish it as a beta version to npm, commit the newly update project version back to the PR, etc.)
* Update readme with new instructions around beta releases
